### PR TITLE
Fix: Clear validation errors on input change (Issue #20)

### DIFF
--- a/dashboard/public/app.js
+++ b/dashboard/public/app.js
@@ -1227,6 +1227,64 @@ class Dashboard {
         document.querySelectorAll('[data-modal-close="new-episode-modal"]').forEach(btn => {
             btn.addEventListener('click', () => this.closeModal('new-episode-modal'));
         });
+
+        // Clear validation errors on input change
+        this.attachValidationErrorClearListeners();
+    }
+
+    /**
+     * Attaches input event listeners to form fields to clear validation errors
+     * when the user starts typing or changes a value.
+     */
+    attachValidationErrorClearListeners() {
+        const seriesSelect = document.getElementById('episode-series-select');
+        const seriesNewInput = document.getElementById('episode-series-new');
+        const topicInput = document.getElementById('episode-topic');
+        const titleInput = document.getElementById('episode-title');
+
+        // Helper function to clear error for a specific field
+        const clearFieldError = (inputElement, errorElementId) => {
+            const errorElement = document.getElementById(errorElementId);
+            if (errorElement) {
+                errorElement.textContent = '';
+            }
+            if (inputElement) {
+                inputElement.classList.remove('error');
+            }
+        };
+
+        // Clear series error when select changes or new series input changes
+        if (seriesSelect) {
+            seriesSelect.addEventListener('change', () => {
+                clearFieldError(seriesSelect, 'series-error');
+                if (seriesNewInput) {
+                    seriesNewInput.classList.remove('error');
+                }
+            });
+        }
+
+        if (seriesNewInput) {
+            seriesNewInput.addEventListener('input', () => {
+                clearFieldError(seriesNewInput, 'series-error');
+                if (seriesSelect) {
+                    seriesSelect.classList.remove('error');
+                }
+            });
+        }
+
+        // Clear topic error when topic input changes
+        if (topicInput) {
+            topicInput.addEventListener('input', () => {
+                clearFieldError(topicInput, 'topic-error');
+            });
+        }
+
+        // Clear title error when title input changes
+        if (titleInput) {
+            titleInput.addEventListener('input', () => {
+                clearFieldError(titleInput, 'title-error');
+            });
+        }
     }
 
     slugify(text) {


### PR DESCRIPTION
## Summary
Fixes #20 - Clear form validation errors on input change

## Problem
Form validation errors persisted even after users started correcting their input, providing no immediate feedback that corrections were being accepted.

## Solution
Added `attachValidationErrorClearListeners()` method that:
- Listens for `input` and `change` events on validated form fields
- Immediately clears error messages when user starts typing
- Removes error styling (red border) from input fields
- Handles both the series dropdown and new series text input

## Fields with error clearing
- Series select/new series input
- Topic input
- Title input

## Test Plan
- [x] All 52 tests pass
- [x] Linting passes
- [ ] Manual test: Submit form with errors, then type in fields to see errors clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)