### PR TITLE
Enhancement: Add error handling, retry, and user feedback (Issue #15)

### DIFF
--- a/dashboard/public/styles.css
+++ b/dashboard/public/styles.css
@@ -2779,3 +2779,122 @@ input[type="date"].edit-field::-webkit-calendar-picker-indicator {
         width: 100%;
     }
 }
+
+/* =============================================================================
+   ERROR BANNER & RECONNECTING INDICATOR
+   ============================================================================= */
+
+/* Error Banner */
+.error-banner {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    background-color: var(--error);
+    color: white;
+    padding: 0.875rem 1.5rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    z-index: 3000;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    animation: error-banner-slide-in 0.3s ease-out;
+}
+
+@keyframes error-banner-slide-in {
+    from {
+        transform: translateY(-100%);
+        opacity: 0;
+    }
+    to {
+        transform: translateY(0);
+        opacity: 1;
+    }
+}
+
+.error-banner-hiding {
+    animation: error-banner-slide-out 0.3s ease-in forwards;
+}
+
+@keyframes error-banner-slide-out {
+    from {
+        transform: translateY(0);
+        opacity: 1;
+    }
+    to {
+        transform: translateY(-100%);
+        opacity: 0;
+    }
+}
+
+.error-banner-message {
+    flex: 1;
+    font-size: 0.9375rem;
+    font-weight: 500;
+}
+
+.error-banner-actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-shrink: 0;
+}
+
+.error-banner-retry,
+.error-banner-dismiss {
+    background-color: rgba(255, 255, 255, 0.2);
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    color: white;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.error-banner-retry:hover,
+.error-banner-dismiss:hover {
+    background-color: rgba(255, 255, 255, 0.3);
+    border-color: rgba(255, 255, 255, 0.5);
+}
+
+.error-banner-retry {
+    background-color: white;
+    color: var(--error);
+    border-color: white;
+}
+
+.error-banner-retry:hover {
+    background-color: rgba(255, 255, 255, 0.9);
+}
+
+/* Reconnecting status indicator animation */
+.status-indicator .dot[style*="warning"] {
+    animation: reconnect-pulse 1s infinite;
+}
+
+@keyframes reconnect-pulse {
+    0%, 100% {
+        opacity: 1;
+        transform: scale(1);
+    }
+    50% {
+        opacity: 0.5;
+        transform: scale(0.85);
+    }
+}
+
+/* Responsive Error Banner */
+@media (max-width: 600px) {
+    .error-banner {
+        flex-direction: column;
+        align-items: stretch;
+        text-align: center;
+        padding: 1rem;
+    }
+
+    .error-banner-actions {
+        justify-content: center;
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #15 - Add error boundaries and retry mechanisms

## Changes

### API Retry with Exponential Backoff
- Retry up to 3 times for 5xx server errors
- Delays: 1s → 2s → 4s (exponential backoff)
- No retry for 4xx client errors (fail fast)
- Handles network failures gracefully

### SSE Reconnection
- Auto-reconnect when connection drops
- Exponential backoff with max 30s delay
- Shows "Reconnecting..." status with attempt counter
- Caps at 10 attempts, then shows error banner

### Global Error Handlers
- `window.onerror` for uncaught JS errors
- `window.onunhandledrejection` for promise rejections
- Logs context to console for debugging
- Shows user-friendly error banners

### Error Banner UI
- Fixed position banner at top of viewport
- Optional retry button for recoverable errors
- Dismiss button for manual close
- Auto-dismiss after 10s (non-retryable errors)
- Smooth slide-in/out animations

## Test Plan
- [x] `npm run lint` passes
- [x] `npm test` - all 52 tests pass
- [ ] Manual: Disconnect network and verify reconnection behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)